### PR TITLE
Clarify which keys are present in ECT authority field

### DIFF
--- a/draft-smith-rats-evidence-trans.md
+++ b/draft-smith-rats-evidence-trans.md
@@ -257,8 +257,8 @@ The completed ECT is added to the `ae` list.
 
 The ECT authority field is an array of `$crypto-keys-type-choice`s.
 
-When adding Evidence to the ACS, the Verifier SHALL add the public key representing the signer of the element (for example the DICE certificate or SPDM MEASUREMENTS response) to this array.
-The Verifier SHALL also add the signer of each certificate which has authorized the signer of the element.
+When adding Evidence to the ACS, the Verifier SHALL add the public key representing the signer of that Evidence (for example the DICE certificate or SPDM MEASUREMENTS response) to the ECT authority field.
+The Verifier SHALL also add the signer of each certificate which has authorized the signer of the signing key.
 
 Having each authority in a certificate path in the ECT `authority` field lets conditional endorsement conditions match multiple authorities or match an authority that is scoped more broadly than the immediate signer of the Evidence artifact.
 

--- a/draft-smith-rats-evidence-trans.md
+++ b/draft-smith-rats-evidence-trans.md
@@ -262,7 +262,7 @@ The Verifier SHALL also add the signer of each certificate which has authorized 
 
 Having each authority in a certificate path in the ECT `authority` field lets conditional endorsement conditions match multiple authorities or match an authority that is scoped more broadly than the immediate signer of the Evidence artifact.
 
-Each signer authority MUST be expressed using the COSE_Key varient of `$crypto-key-type-choice`.
+Each signer authority value MUST be represented using `tagged-cose-key-type`.
 
 # Transforming TCG Concise Evidence {#sec-ce-trans}
 

--- a/draft-smith-rats-evidence-trans.md
+++ b/draft-smith-rats-evidence-trans.md
@@ -258,7 +258,7 @@ The completed ECT is added to the `ae` list.
 The ECT authority field is an array of `$crypto-keys-type-choice`s.
 
 When adding Evidence to the ACS, the Verifier SHALL add the public key representing the signer of the element (for example the DICE certificate or SPDM MEASUREMENTS response) to this array.
-The Verifier SHALL also add the signer of each certificate which has authorized (either directly or indirectly) the signer of the element.
+The Verifier SHALL also add the signer of each certificate which has authorized the signer of the element.
 
 Having each authority in a certificate path in the ECT `authority` field lets conditional endorsement conditions match multiple authorities or match an authority that is scoped more broadly than the immediate signer of the Evidence artifact.
 

--- a/draft-smith-rats-evidence-trans.md
+++ b/draft-smith-rats-evidence-trans.md
@@ -260,9 +260,9 @@ The ECT authority field is an array of `$crypto-keys-type-choice`s.
 When adding Evidence to the ACS, the Verifier SHALL add the public key representing the signer of the element (for example the DICE certificate or SPDM MEASUREMENTS response) to this array.
 The Verifier SHALL also add the signer of each certificate which has authorized (either directly or indirectly) the signer of the element.
 
-This lets conditional endorsers use a global key when creating endorsement conditions intended to match against evidence from multiple attestors of the same class.
+Having each authority in a certificate path in the ECT `authority` field lets conditional endorsement conditions match multiple authorities or match an authority that is scoped more broadly than the immediate signer of the Evidence artifact.
 
-Each signer identity MUST be expressed using the COSE_Key varient of `$crypto-key-type-choice`.
+Each signer authority MUST be expressed using the COSE_Key varient of `$crypto-key-type-choice`.
 
 # Transforming TCG Concise Evidence {#sec-ce-trans}
 
@@ -332,7 +332,7 @@ The SPDM measurements are converted to `concise-evidence` which has a format tha
 The TCG DICE Concise Evidence Binding for SPDM specification {{-ce}} describes a process for converting the SPDM Measurement Block to Concise Evidence.
 Subsequently the transformation steps defined in {{sec-ce-trans}}.
 
-The keys provided in the ECT.`authority` field should include global (not device-specific) keys which signed the SPDM MEASUREMENTS response carrying the Evidence as described in {{sec-authority}}.
+The keys provided in the ECT.`authority` field SHOULD include the key which signed the SPDM MEASUREMENTS response carrying the Evidence as described in {{sec-authority}}, the DeviceID key which authorized that key and keys which authorized the DeviceID key.```
 
 # Security and Privacy Considerations {#sec-sec}
 

--- a/draft-smith-rats-evidence-trans.md
+++ b/draft-smith-rats-evidence-trans.md
@@ -249,11 +249,20 @@ The binary representation of DTI.`type` MUST be equivalent to the binary represe
 > > If _m_.`notTcb` = 1 AND _f_.`notTcb` = 0; **set**(ECT.`element-list`.`element-map`.`measurement-values-map`.`flags`.`is-tcb` = TRUE).
 
 {: dtt-enum}
-* The signer of the certificate containing DTI is copied to the ECT.`authority` field.
-The signer identity MUST be expressed using `$crypto-key-type-choice`.
-A profile or other arrangement is used to coordinate which `$crypto-key-type-choice` is used for both Evidence and Reference Values.
+* The ECT.`authority` field is set up based on the signer of the certificate containing DTI as described in {{sec-authority}}.
 
 The completed ECT is added to the `ae` list.
+
+## Authority field in DICE/SPDM ECTs {#sec-authority}
+
+The ECT authority field is an array of `$crypto-keys-type-choice`s.
+
+When adding Evidence to the ACS, the Verifier SHALL add the public key representing the signer of the element (for example the DICE certificate or SPDM MEASUREMENTS response) to this array.
+The Verifier SHALL also add the signer of each certificate which has authorized (either directly or indirectly) the signer of the element.
+
+This lets conditional endorsers use a global key when creating endorsement conditions intended to match against evidence from multiple attestors of the same class.
+
+Each signer identity MUST be expressed using the COSE_Key varient of `$crypto-key-type-choice`.
 
 # Transforming TCG Concise Evidence {#sec-ce-trans}
 
@@ -300,7 +309,7 @@ For each `evidence-triple-record` and `ae` ECT is constructed.
 > > **copy**(e.`measurement-map`.`mval`, ECT.`element-list`.`element-map`.`element-claims`)
 
 {: cet-enum}
-* The signer of the envelope containing CE is copied to the ECT.`authority` field.
+* The signer of the envelope containing CE is copied to the ECT.`authority` field as described in {{sec-authority}.
 For example, a CE may be wrapped by an EAT token {{-eat}} or DICE certificate {{-dice-attest}}.
 The signer identity MUST be expressed using `$crypto-key-type-choice`.
 A profile or other arrangement is used to coordinate which `$crypto-key-type-choice` is used for both Evidence and Reference Values.
@@ -322,6 +331,8 @@ Verifiers supporting the SPDM Evidence format SHOULD implement this transformati
 The SPDM measurements are converted to `concise-evidence` which has a format that is similar to CoRIM `triples-map` (their semantics follows the matching rules described above).
 The TCG DICE Concise Evidence Binding for SPDM specification {{-ce}} describes a process for converting the SPDM Measurement Block to Concise Evidence.
 Subsequently the transformation steps defined in {{sec-ce-trans}}.
+
+The keys provided in the ECT.`authority` field should include global (not device-specific) keys which signed the SPDM MEASUREMENTS response carrying the Evidence as described in {{sec-authority}}.
 
 # Security and Privacy Considerations {#sec-sec}
 

--- a/draft-smith-rats-evidence-trans.md
+++ b/draft-smith-rats-evidence-trans.md
@@ -332,7 +332,7 @@ The SPDM measurements are converted to `concise-evidence` which has a format tha
 The TCG DICE Concise Evidence Binding for SPDM specification {{-ce}} describes a process for converting the SPDM Measurement Block to Concise Evidence.
 Subsequently the transformation steps defined in {{sec-ce-trans}}.
 
-The keys provided in the ECT.`authority` field SHOULD include the key which signed the SPDM MEASUREMENTS response carrying the Evidence as described in {{sec-authority}}, the DeviceID key which authorized that key and keys which authorized the DeviceID key.```
+The keys provided in the ECT.`authority` field SHOULD include the key which signed the SPDM MEASUREMENTS response carrying the Evidence and keys which authorized that key as described in {{sec-authority}}.```
 
 # Security and Privacy Considerations {#sec-sec}
 


### PR DESCRIPTION
Text to answer issue #5. This text sets the authority field to include global keys at/near the top of the certificate chain.