### PR TITLE
Transform TCBInfo 'index' field into measurement-map.mkey rather than…

### DIFF
--- a/draft-smith-rats-evidence-trans.md
+++ b/draft-smith-rats-evidence-trans.md
@@ -183,7 +183,6 @@ The binary representation of DTI.`type` MUST be equivalent to the binary represe
 
 > > **copy**(DTI.`layer`, ECT.`environment`.`environment-map`.`class-map`.`layer`).
 
-> > **copy**(DTI.`index`, ECT.`environment`.`environment-map`.`class-map`.`index`).
 
 {: dtt2-enum}
 * The DTI entry populates the `ae` ECT `elemenet-list`.
@@ -197,6 +196,8 @@ The binary representation of DTI.`type` MUST be equivalent to the binary represe
 > > Foreach FWID in FWIDLIST: **copy**(DTI.`FWID`.`digest`, ECT.`element-list`.`element-map`.`measurement-values-map`.`digests`.`digest`.`val`).
 
 > > Foreach FWID in FWIDLIST: **copy**(DTI.`FWID`.`hashAlg`, ECT.`element-list`.`element-map`.`measurement-values-map`.`digests`.`digest`.`alg`).
+
+> > **copy**(DTI.`index`, ECT.`element-list`.`element-map`.`measured-element-type-choice`.`mkey`).
 
 {: dtt2-enum}
 * The DTI entry populates the `ae` ECT `elemenet-list`.`flags`. Foreach _f_ in DTI.`OperationalFlags` and each _m_ in DTI.`OperationalFlagsMask`:


### PR DESCRIPTION
… environment-map.index

This allows users more flexible usage of multi-tcb-info by combining multiple TCBInfo to describe the same target environment